### PR TITLE
added $PARA_PATH to en-sw unzip command

### DIFF
--- a/get-data-para.sh
+++ b/get-data-para.sh
@@ -118,10 +118,10 @@ if [ $pair == "en-sw" ]; then
   echo "Download parallel data for English-Swahili"
   # Tanzil
   wget -c http://opus.nlpl.eu/download.php?f=Tanzil%2Fen-sw.txt.zip -P $PARA_PATH
-  unzip -u download.php?f=Tanzil%2Fen-sw.txt.zip -d $PARA_PATH
+  unzip -u $PARA_PATH/download.php?f=Tanzil%2Fen-sw.txt.zip -d $PARA_PATH
   # GlobalVoices
   wget -c http://opus.nlpl.eu/download.php?f=GlobalVoices%2Fen-sw.txt.zip -P $PARA_PATH
-  unzip -u download.php?f=GlobalVoices%2Fen-sw.txt.zip -d $PARA_PATH
+  unzip -u $PARA_PATH/download.php?f=GlobalVoices%2Fen-sw.txt.zip -d $PARA_PATH
 fi
 
 # en-th


### PR DESCRIPTION
Downloading pair of en-sw data needed the path to parallel data. Fixed it by adding 
`$PARA_PATH` to `line 121` and `124` on `get-data-para.sh` script